### PR TITLE
Wait for new epoch before generating proof

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,7 +60,7 @@ var ProveCmd = &cli.Command{
 	Usage:       "Generate proof calldata for NativeProver.prove() function",
 	Description: "Generate the calldata for a transaction calling the NativeProver.prove() function",
 	Action:      prove,
-	Flags:       fallback_prover.Flags,
+	Flags:       fallback_prover.L2Flags,
 }
 
 var UpdateAndProveCmd = &cli.Command{
@@ -68,7 +68,7 @@ var UpdateAndProveCmd = &cli.Command{
 	Usage:       "Generate proof calldata for NativeProver.updateAndProve() function",
 	Description: "Generate the calldata for a transaction calling the NativeProver.updateAndProve() function",
 	Action:      updateAndProve,
-	Flags:       fallback_prover.Flags,
+	Flags:       fallback_prover.L2Flags,
 }
 
 var ConfigureAndProveCmd = &cli.Command{
@@ -76,7 +76,7 @@ var ConfigureAndProveCmd = &cli.Command{
 	Usage:       "Generate proof calldata for NativeProver.configureAndProve() function",
 	Description: "Generate the calldata for a transaction calling the NativeProver.configureAndProve() function",
 	Action:      configureAndProve,
-	Flags:       fallback_prover.Flags,
+	Flags:       fallback_prover.L2Flags,
 }
 
 var ProveL1Cmd = &cli.Command{
@@ -84,29 +84,27 @@ var ProveL1Cmd = &cli.Command{
 	Usage:       "Generate proof calldata for NativeProver.proveL1() function",
 	Description: "Generate the calldata for a transaction calling the NativeProver.proveL1() function",
 	Action:      proveL1,
-	Flags:       fallback_prover.Flags,
+	Flags:       fallback_prover.L1Flags,
 }
 
 func prove(c *cli.Context) error {
-	if err := fallback_prover.CheckRequired(c); err != nil {
+	if err := fallback_prover.CheckRequiredL2(c); err != nil {
 		return err
 	}
 
 	config := fallback_prover.NewConfigFromCLI(c)
+	params := fallback_prover.NewParamsFromCLI(c)
 
 	log.Info("Generating prove() calldata",
 		"srcL2ChainID", config.SrcL2ChainID,
 		"dstL2ChainID", config.DstL2ChainID,
-		"srcAddress", config.SrcAddress,
-		"srcStorageSlot", config.SrcStorageSlot)
+		"srcAddress", params.Address,
+		"srcStorageSlot", params.StorageSlot)
 
 	// Initialize the prover
 	prover, err := fallback_prover.NewProver(
-		config.L1HTTPPath,
-		config.SrcL2RPC,
-		config.DstL2RPC,
-		config.SrcL2ChainID,
-		config.RegistryAddress,
+		c.Context,
+		config,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize prover: %w", err)
@@ -115,10 +113,7 @@ func prove(c *cli.Context) error {
 	// Generate proof calldata
 	calldata, err := prover.GenerateProveCalldata(
 		c.Context,
-		config.SrcL2ChainID,
-		config.DstL2ChainID,
-		config.SrcAddress,
-		config.SrcStorageSlot,
+		params,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate proof calldata: %w", err)
@@ -130,23 +125,22 @@ func prove(c *cli.Context) error {
 }
 
 func proveL1(c *cli.Context) error {
-	if err := fallback_prover.CheckRequired(c); err != nil {
+	if err := fallback_prover.CheckRequiredL1(c); err != nil {
 		return err
 	}
 
-	config := fallback_prover.NewConfigFromCLI(c)
+	config := fallback_prover.NewL1ConfigFromCLI(c)
+	params := fallback_prover.NewParamsFromCLI(c)
 
 	log.Info("Generating proveL1() calldata",
-		"srcL2ChainID", config.SrcL2ChainID,
 		"dstL2ChainID", config.DstL2ChainID,
-		"srcAddress", config.SrcAddress,
-		"srcStorageSlot", config.SrcStorageSlot)
+		"srcAddress", params.Address,
+		"srcStorageSlot", params.StorageSlot)
 
 	// Initialize the prover
 	prover, err := fallback_prover.NewL1Prover(
-		config.L1HTTPPath,
-		config.DstL2RPC,
-		config.RegistryAddress,
+		c.Context,
+		config,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize prover: %w", err)
@@ -155,9 +149,7 @@ func proveL1(c *cli.Context) error {
 	// Generate proof calldata
 	calldata, err := prover.GenerateProveL1Calldata(
 		c.Context,
-		config.DstL2ChainID,
-		config.SrcAddress,
-		config.SrcStorageSlot,
+		params,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate proof calldata: %w", err)
@@ -169,25 +161,23 @@ func proveL1(c *cli.Context) error {
 }
 
 func updateAndProve(c *cli.Context) error {
-	if err := fallback_prover.CheckRequired(c); err != nil {
+	if err := fallback_prover.CheckRequiredL2(c); err != nil {
 		return err
 	}
 
 	config := fallback_prover.NewConfigFromCLI(c)
+	params := fallback_prover.NewParamsFromCLI(c)
 
 	log.Info("Generating updateAndProve() calldata",
 		"srcL2ChainID", config.SrcL2ChainID,
 		"dstL2ChainID", config.DstL2ChainID,
-		"srcAddress", config.SrcAddress,
-		"srcStorageSlot", config.SrcStorageSlot)
+		"srcAddress", params.Address,
+		"srcStorageSlot", params.StorageSlot)
 
 	// Initialize the prover
 	prover, err := fallback_prover.NewProver(
-		config.L1HTTPPath,
-		config.SrcL2RPC,
-		config.DstL2RPC,
-		config.SrcL2ChainID,
-		config.RegistryAddress,
+		c.Context,
+		config,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize prover: %w", err)
@@ -196,10 +186,7 @@ func updateAndProve(c *cli.Context) error {
 	// Generate updateAndProve calldata
 	calldata, err := prover.GenerateUpdateAndProveCalldata(
 		c.Context,
-		config.SrcL2ChainID,
-		config.DstL2ChainID,
-		config.SrcAddress,
-		config.SrcStorageSlot,
+		params,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate updateAndProve calldata: %w", err)
@@ -211,25 +198,23 @@ func updateAndProve(c *cli.Context) error {
 }
 
 func configureAndProve(c *cli.Context) error {
-	if err := fallback_prover.CheckRequired(c); err != nil {
+	if err := fallback_prover.CheckRequiredL2(c); err != nil {
 		return err
 	}
 
 	config := fallback_prover.NewConfigFromCLI(c)
+	params := fallback_prover.NewParamsFromCLI(c)
 
 	log.Info("Generating configureAndProve() calldata",
 		"srcL2ChainID", config.SrcL2ChainID,
 		"dstL2ChainID", config.DstL2ChainID,
-		"srcAddress", config.SrcAddress,
-		"srcStorageSlot", config.SrcStorageSlot)
+		"srcAddress", params.Address,
+		"srcStorageSlot", params.StorageSlot)
 
 	// Initialize the prover
 	prover, err := fallback_prover.NewProver(
-		config.L1HTTPPath,
-		config.SrcL2RPC,
-		config.DstL2RPC,
-		config.SrcL2ChainID,
-		config.RegistryAddress,
+		c.Context,
+		config,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize prover: %w", err)
@@ -238,10 +223,7 @@ func configureAndProve(c *cli.Context) error {
 	// Generate configureAndProve calldata
 	calldata, err := prover.GenerateConfigureAndProveCalldata(
 		c.Context,
-		config.SrcL2ChainID,
-		config.DstL2ChainID,
-		config.SrcAddress,
-		config.SrcStorageSlot,
+		params,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate configureAndProve calldata: %w", err)

--- a/config.go
+++ b/config.go
@@ -29,12 +29,14 @@ type ProveL1Config struct {
 	L1HTTPPath      string
 	DstL2RPC        string
 	RegistryAddress common.Address
-	WaitForNewEpoch bool
 }
 
 type ProveParams struct {
-	Address     common.Address
-	StorageSlot common.Hash
+	Address           common.Address
+	StorageSlot       common.Hash
+	WaitForNewEpoch   bool
+	EpochPollingFreq  uint
+	EpochPollingTries uint
 }
 
 // NewConfigFromCLI creates a config from the provided *cli.Context
@@ -56,13 +58,15 @@ func NewL1ConfigFromCLI(ctx *cli.Context) *ProveL1Config {
 		DstL2RPC:        ctx.String(DstL2HTTPPath.Name),
 		DstL2ChainID:    ctx.Uint64(DstL2ChainID.Name),
 		RegistryAddress: common.HexToAddress(ctx.String(L1RegistryAddress.Name)),
-		WaitForNewEpoch: ctx.Bool(WaitForNewEpoch.Name),
 	}
 }
 
 func NewParamsFromCLI(ctx *cli.Context) *ProveParams {
 	return &ProveParams{
-		Address:     common.HexToAddress(ctx.String(SrcContractAddress.Name)),
-		StorageSlot: common.HexToHash(ctx.String(SrcStorageSlot.Name)),
+		Address:           common.HexToAddress(ctx.String(SrcContractAddress.Name)),
+		StorageSlot:       common.HexToHash(ctx.String(SrcStorageSlot.Name)),
+		WaitForNewEpoch:   ctx.Bool(WaitForNewEpoch.Name),
+		EpochPollingFreq:  ctx.Uint(EpochPollingFreq.Name),
+		EpochPollingTries: ctx.Uint(EpochPollingTries.Name),
 	}
 }

--- a/config.go
+++ b/config.go
@@ -12,29 +12,57 @@ type L2ConfigInfo struct {
 	StorageSlots []uint64
 }
 
-// Config contains the configuration for the native-prover
-type Config struct {
-	// Additional fields for the prove command
+// ProveConfig contains the configuration for proving a storage slot on a src L2
+type ProveConfig struct {
 	SrcL2ChainID    uint64
 	DstL2ChainID    uint64
 	L1HTTPPath      string
 	SrcL2RPC        string
 	DstL2RPC        string
-	SrcAddress      common.Address
-	SrcStorageSlot  common.Hash
 	RegistryAddress common.Address
+	WaitForNewEpoch bool
+}
+
+// ProveL1Config contains the configuration for proving a storage slot on an L1
+type ProveL1Config struct {
+	DstL2ChainID    uint64
+	L1HTTPPath      string
+	DstL2RPC        string
+	RegistryAddress common.Address
+	WaitForNewEpoch bool
+}
+
+type ProveParams struct {
+	Address     common.Address
+	StorageSlot common.Hash
 }
 
 // NewConfigFromCLI creates a config from the provided *cli.Context
-func NewConfigFromCLI(ctx *cli.Context) *Config {
-	return &Config{
+func NewConfigFromCLI(ctx *cli.Context) *ProveConfig {
+	return &ProveConfig{
 		L1HTTPPath:      ctx.String(L1HTTPPath.Name),
 		SrcL2RPC:        ctx.String(SrcL2HTTPPath.Name),
 		DstL2RPC:        ctx.String(DstL2HTTPPath.Name),
 		SrcL2ChainID:    ctx.Uint64(SrcL2ChainID.Name),
 		DstL2ChainID:    ctx.Uint64(DstL2ChainID.Name),
-		SrcAddress:      common.HexToAddress(ctx.String(SrcL2ContractAddress.Name)),
-		SrcStorageSlot:  common.HexToHash(ctx.String(SrcL2StorageSlot.Name)),
 		RegistryAddress: common.HexToAddress(ctx.String(L1RegistryAddress.Name)),
+		WaitForNewEpoch: ctx.Bool(WaitForNewEpoch.Name),
+	}
+}
+
+func NewL1ConfigFromCLI(ctx *cli.Context) *ProveL1Config {
+	return &ProveL1Config{
+		L1HTTPPath:      ctx.String(L1HTTPPath.Name),
+		DstL2RPC:        ctx.String(DstL2HTTPPath.Name),
+		DstL2ChainID:    ctx.Uint64(DstL2ChainID.Name),
+		RegistryAddress: common.HexToAddress(ctx.String(L1RegistryAddress.Name)),
+		WaitForNewEpoch: ctx.Bool(WaitForNewEpoch.Name),
+	}
+}
+
+func NewParamsFromCLI(ctx *cli.Context) *ProveParams {
+	return &ProveParams{
+		Address:     common.HexToAddress(ctx.String(SrcContractAddress.Name)),
+		StorageSlot: common.HexToHash(ctx.String(SrcStorageSlot.Name)),
 	}
 }

--- a/flags.go
+++ b/flags.go
@@ -68,6 +68,18 @@ var (
 		EnvVars: prefixEnvVars("WAIT_FOR_NEW_EPOCH"),
 		Value:   true,
 	}
+	EpochPollingFreq = &cli.UintFlag{
+		Name:    "epoch-polling-freq",
+		Usage:   "When wait-for-new-epoch is enabled this configures how often (in seconds) to check for a new epoch",
+		EnvVars: prefixEnvVars("EPOCH_POLLING_FREQ"),
+		Value:   1,
+	}
+	EpochPollingTries = &cli.UintFlag{
+		Name:    "epoch-polling-tries",
+		Usage:   "When wait-for-new-epoch is enabled this configures how many times to query for a new epoch before giving up",
+		EnvVars: prefixEnvVars("EPOCH_POLLING_TRIES"),
+		Value:   10,
+	}
 )
 
 var requiredProveFlags = []cli.Flag{
@@ -91,6 +103,8 @@ var requiredProveL1Flags = []cli.Flag{
 var optionalFlags = []cli.Flag{
 	L1RegistryAddress,
 	WaitForNewEpoch,
+	EpochPollingFreq,
+	EpochPollingTries,
 }
 
 // L2Flags contains the list of configuration options available for the prove commands

--- a/l1prover_test.go
+++ b/l1prover_test.go
@@ -17,7 +17,6 @@ import (
 
 func TestL1Prover_GenerateProveL1Calldata(t *testing.T) {
 	// Create test data
-	dstL2ChainID := uint64(42161) // Arbitrum chain ID
 	l1Address := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
 	l1StorageSlot := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
 
@@ -35,12 +34,6 @@ func TestL1Prover_GenerateProveL1Calldata(t *testing.T) {
 	mockAccountProof := [][]byte{[]byte("account-proof-1"), []byte("account-proof-2")}
 
 	// Create mock provers
-	mockRegistryProver := &testutil.MockRegistryProver{
-		GetL1BlockHashOracleFunc: func(ctx context.Context, chainID uint64) (common.Address, error) {
-			return common.HexToAddress("0x5678"), nil
-		},
-	}
-
 	mockL1OriginProver := &testutil.MockL1OriginProver{
 		ProveL1OriginFunc: func(ctx context.Context, l1OracleAddress common.Address) ([]byte, *types.Header, error) {
 			return rlpEncodedL1Header, l1Block.Header(), nil
@@ -62,18 +55,19 @@ func TestL1Prover_GenerateProveL1Calldata(t *testing.T) {
 
 	// Create the L1Prover instance with mocked interfaces and real NativeProver
 	prover := &L1Prover{
-		registryProver:  mockRegistryProver,
-		l1OriginProver:  mockL1OriginProver,
-		l1StorageProver: mockStorageProver,
-		nativeProver:    nativeProver,
+		l1OriginProver:    mockL1OriginProver,
+		l1StorageProver:   mockStorageProver,
+		nativeProver:      nativeProver,
+		l1BlockHashOracle: common.HexToAddress("0x5678"),
 	}
 
 	// Call the method being tested
 	calldata, err := prover.GenerateProveL1Calldata(
 		context.Background(),
-		dstL2ChainID,
-		l1Address,
-		l1StorageSlot,
+		&ProveParams{
+			Address:     l1Address,
+			StorageSlot: l1StorageSlot,
+		},
 	)
 	require.NoError(t, err)
 

--- a/l1prover_test.go
+++ b/l1prover_test.go
@@ -35,8 +35,11 @@ func TestL1Prover_GenerateProveL1Calldata(t *testing.T) {
 
 	// Create mock provers
 	mockL1OriginProver := &testutil.MockL1OriginProver{
-		ProveL1OriginFunc: func(ctx context.Context, l1OracleAddress common.Address) ([]byte, *types.Header, error) {
+		GetL1OriginFunc: func(ctx context.Context, l1Hash common.Hash) ([]byte, *types.Header, error) {
 			return rlpEncodedL1Header, l1Block.Header(), nil
+		},
+		GetL1OriginHashFunc: func(ctx context.Context, l1OracleAddress common.Address) (common.Hash, error) {
+			return l1Block.Hash(), nil
 		},
 	}
 

--- a/prover.go
+++ b/prover.go
@@ -16,46 +16,57 @@ import (
 
 // Prover is the main entry point for generating proofs
 type Prover struct {
-	registryProver     provers.IRegistryProver
 	l1OriginProver     provers.IL1OriginProver
 	nativeProver       provers.INativeProver
 	l2StorageProver    provers.IStorageProver
 	settledStateProver provers.ISettledStateProver
 	l2Config           *types.L2ConfigInfo
+	l1BlockHashOracle  common.Address
+	srcChainID         *big.Int
+	configProof        *types.UpdateL2ConfigArgs
 }
 
 // NewProver initializes a new prover with the given RPC endpoints
-func NewProver(l1RPCEndpoint, srcL2RPCEndpoint, dstL2RPCEndpoint string, srcL2ChainID uint64, registryAddr common.Address) (*Prover, error) {
+func NewProver(ctx context.Context, conf *ProveConfig) (*Prover, error) {
 	// Set up L1 clients
-	l1RPC, err := rpc.Dial(l1RPCEndpoint)
+	l1RPC, err := rpc.Dial(conf.L1HTTPPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to L1 RPC: %w", err)
 	}
 	l1Client := ethclient.NewClient(l1RPC)
 
 	// Set up source L2 clients
-	srcL2RPC, err := rpc.Dial(srcL2RPCEndpoint)
+	srcL2RPC, err := rpc.Dial(conf.SrcL2RPC)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to source L2 RPC: %w", err)
 	}
 	srcL2Client := ethclient.NewClient(srcL2RPC)
 
 	// Set up destination L2 clients
-	dstL2RPC, err := rpc.Dial(dstL2RPCEndpoint)
+	dstL2RPC, err := rpc.Dial(conf.DstL2RPC)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to destination L2 RPC: %w", err)
 	}
 	dstL2Client := ethclient.NewClient(dstL2RPC)
 
-	registryProver := provers.NewRegistryProver(l1Client, l1RPC, registryAddr)
+	registryProver := provers.NewRegistryProver(l1Client, l1RPC, conf.RegistryAddress)
+	l1BlockHashOracle, err := registryProver.GetL1BlockHashOracle(ctx, conf.DstL2ChainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get L1 block hash oracle: %w", err)
+	}
+
 	nativeProver, err := provers.NewNativeProver()
 	if err != nil {
 		return nil, err
 	}
 
-	l2Config, err := registryProver.GetL2Configuration(context.Background(), srcL2ChainID)
+	l2Config, err := registryProver.GetL2Configuration(context.Background(), conf.SrcL2ChainID)
 	if err != nil {
 		return nil, err
+	}
+	l2ConfigProof, err := registryProver.GenerateUpdateL2ConfigArgs(ctx, conf.SrcL2ChainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate L2 config proof: %w", err)
 	}
 
 	var settledStateProver provers.ISettledStateProver
@@ -73,29 +84,23 @@ func NewProver(l1RPCEndpoint, srcL2RPCEndpoint, dstL2RPCEndpoint string, srcL2Ch
 		return nil, fmt.Errorf("unsupported L2 config type: %s", l2Config.ConfigType)
 	}
 	return &Prover{
-		registryProver:     registryProver,
 		l1OriginProver:     provers.NewL1OriginProver(l1Client, dstL2Client),
 		l2StorageProver:    provers.NewStorageProver(srcL2Client, srcL2RPC),
 		nativeProver:       nativeProver,
 		settledStateProver: settledStateProver,
 		l2Config:           l2Config,
+		l1BlockHashOracle:  l1BlockHashOracle,
+		srcChainID:         big.NewInt(int64(conf.SrcL2ChainID)),
+		configProof:        l2ConfigProof,
 	}, nil
 }
 
 // GenerateProveCalldata generates the calldata for the NativeProver.prove() function
 func (p *Prover) GenerateProveCalldata(
 	ctx context.Context,
-	srcL2ChainID uint64,
-	dstL2ChainID uint64,
-	srcAddress common.Address,
-	srcStorageSlot common.Hash,
+	params *ProveParams,
 ) (string, error) {
-	l1BlockHashOracle, err := p.registryProver.GetL1BlockHashOracle(ctx, dstL2ChainID)
-	if err != nil {
-		return "", fmt.Errorf("failed to get L1 block hash oracle: %w", err)
-	}
-
-	rlpEncodedL1Header, l1Header, err := p.l1OriginProver.ProveL1Origin(ctx, l1BlockHashOracle)
+	rlpEncodedL1Header, l1Header, err := p.l1OriginProver.ProveL1Origin(ctx, p.l1BlockHashOracle)
 	if err != nil {
 		return "", fmt.Errorf("failed to get L1 origin: %w", err)
 	}
@@ -108,7 +113,7 @@ func (p *Prover) GenerateProveCalldata(
 		return "", fmt.Errorf("failed to generate %s settled state proof: %w", p.l2Config.ConfigType, err)
 	}
 
-	result, err := p.l2StorageProver.GetStorageAt(ctx, srcAddress, srcStorageSlot, l2Header.Number)
+	result, err := p.l2StorageProver.GetStorageAt(ctx, params.Address, params.StorageSlot, l2Header.Number)
 	if err != nil {
 		return "", fmt.Errorf("failed to get storage value: %w", err)
 	}
@@ -116,8 +121,8 @@ func (p *Prover) GenerateProveCalldata(
 
 	l2StorageProof, rlpEncodedContractAccount, l2AccountProof, err := p.l2StorageProver.GenerateStorageProof(
 		ctx,
-		srcAddress,
-		srcStorageSlot,
+		params.Address,
+		params.StorageSlot,
 		l2Header.Root,
 	)
 	if err != nil {
@@ -126,9 +131,9 @@ func (p *Prover) GenerateProveCalldata(
 
 	// Create ProveScalarArgs for the Prove call
 	proveArgs := types.ProveScalarArgs{
-		ChainID:          big.NewInt(int64(srcL2ChainID)),
-		ContractAddr:     srcAddress,
-		StorageSlot:      srcStorageSlot,
+		ChainID:          p.srcChainID,
+		ContractAddr:     params.Address,
+		StorageSlot:      params.StorageSlot,
 		StorageValue:     storageValue,
 		L2WorldStateRoot: l2Header.Root,
 	}
@@ -158,25 +163,11 @@ func (p *Prover) GenerateProveCalldata(
 // GenerateUpdateAndProveCalldata generates the calldata for the NativeProver.updateAndProve() function
 func (p *Prover) GenerateUpdateAndProveCalldata(
 	ctx context.Context,
-	srcL2ChainID uint64,
-	dstL2ChainID uint64,
-	srcAddress common.Address,
-	srcStorageSlot common.Hash,
+	params *ProveParams,
 ) (string, error) {
-	l1BlockHashOracle, err := p.registryProver.GetL1BlockHashOracle(ctx, dstL2ChainID)
-	if err != nil {
-		return "", fmt.Errorf("failed to get L1 block hash oracle: %w", err)
-	}
-
-	rlpEncodedL1Header, l1Header, err := p.l1OriginProver.ProveL1Origin(ctx, l1BlockHashOracle)
+	rlpEncodedL1Header, l1Header, err := p.l1OriginProver.ProveL1Origin(ctx, p.l1BlockHashOracle)
 	if err != nil {
 		return "", fmt.Errorf("failed to get L1 origin: %w", err)
-	}
-
-	// Generate the UpdateL2ConfigArgs from the registry
-	updateConfig, err := p.registryProver.GenerateUpdateL2ConfigArgs(ctx, srcL2ChainID)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate update L2 config args: %w", err)
 	}
 
 	settledStateProof, l2Header, err := p.settledStateProver.GenerateSettledStateProof(
@@ -187,7 +178,7 @@ func (p *Prover) GenerateUpdateAndProveCalldata(
 		return "", fmt.Errorf("failed to generate %s settled state proof: %w", p.l2Config.ConfigType, err)
 	}
 
-	result, err := p.l2StorageProver.GetStorageAt(ctx, srcAddress, srcStorageSlot, l2Header.Number)
+	result, err := p.l2StorageProver.GetStorageAt(ctx, params.Address, params.StorageSlot, l2Header.Number)
 	if err != nil {
 		return "", fmt.Errorf("failed to get storage value: %w", err)
 	}
@@ -195,8 +186,8 @@ func (p *Prover) GenerateUpdateAndProveCalldata(
 
 	l2StorageProof, rlpEncodedContractAccount, l2AccountProof, err := p.l2StorageProver.GenerateStorageProof(
 		ctx,
-		srcAddress,
-		srcStorageSlot,
+		params.Address,
+		params.StorageSlot,
 		l2Header.Root,
 	)
 	if err != nil {
@@ -205,9 +196,9 @@ func (p *Prover) GenerateUpdateAndProveCalldata(
 
 	// Create ProveScalarArgs for the updateAndProve call
 	proveArgs := types.ProveScalarArgs{
-		ChainID:          big.NewInt(int64(srcL2ChainID)),
-		ContractAddr:     srcAddress,
-		StorageSlot:      srcStorageSlot,
+		ChainID:          p.srcChainID,
+		ContractAddr:     params.Address,
+		StorageSlot:      params.StorageSlot,
 		StorageValue:     storageValue,
 		L2WorldStateRoot: l2Header.Root,
 	}
@@ -218,7 +209,7 @@ func (p *Prover) GenerateUpdateAndProveCalldata(
 	}
 
 	calldata, err := p.nativeProver.EncodeUpdateAndProveCalldata(
-		*updateConfig,
+		*p.configProof,
 		proveArgs,
 		rlpEncodedL1Header,
 		rlpEncodedL2Header,
@@ -238,25 +229,11 @@ func (p *Prover) GenerateUpdateAndProveCalldata(
 // GenerateConfigureAndProveCalldata generates the calldata for the NativeProver.configureAndProve() function
 func (p *Prover) GenerateConfigureAndProveCalldata(
 	ctx context.Context,
-	srcL2ChainID uint64,
-	dstL2ChainID uint64,
-	srcAddress common.Address,
-	srcStorageSlot common.Hash,
+	params *ProveParams,
 ) (string, error) {
-	l1BlockHashOracle, err := p.registryProver.GetL1BlockHashOracle(ctx, dstL2ChainID)
-	if err != nil {
-		return "", fmt.Errorf("failed to get L1 block hash oracle: %w", err)
-	}
-
-	rlpEncodedL1Header, l1Header, err := p.l1OriginProver.ProveL1Origin(ctx, l1BlockHashOracle)
+	rlpEncodedL1Header, l1Header, err := p.l1OriginProver.ProveL1Origin(ctx, p.l1BlockHashOracle)
 	if err != nil {
 		return "", fmt.Errorf("failed to get L1 origin: %w", err)
-	}
-
-	// Generate the UpdateL2ConfigArgs from the registry
-	updateConfig, err := p.registryProver.GenerateUpdateL2ConfigArgs(ctx, srcL2ChainID)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate update L2 config args: %w", err)
 	}
 
 	settledStateProof, l2Header, err := p.settledStateProver.GenerateSettledStateProof(
@@ -267,7 +244,7 @@ func (p *Prover) GenerateConfigureAndProveCalldata(
 		return "", fmt.Errorf("failed to generate %s settled state proof: %w", p.l2Config.ConfigType, err)
 	}
 
-	result, err := p.l2StorageProver.GetStorageAt(ctx, srcAddress, srcStorageSlot, l2Header.Number)
+	result, err := p.l2StorageProver.GetStorageAt(ctx, params.Address, params.StorageSlot, l2Header.Number)
 	if err != nil {
 		return "", fmt.Errorf("failed to get storage value: %w", err)
 	}
@@ -275,8 +252,8 @@ func (p *Prover) GenerateConfigureAndProveCalldata(
 
 	l2StorageProof, rlpEncodedContractAccount, l2AccountProof, err := p.l2StorageProver.GenerateStorageProof(
 		ctx,
-		srcAddress,
-		srcStorageSlot,
+		params.Address,
+		params.StorageSlot,
 		l2Header.Root,
 	)
 	if err != nil {
@@ -285,9 +262,9 @@ func (p *Prover) GenerateConfigureAndProveCalldata(
 
 	// Create ProveScalarArgs for the configureAndProve call
 	proveArgs := types.ProveScalarArgs{
-		ChainID:          big.NewInt(int64(srcL2ChainID)),
-		ContractAddr:     srcAddress,
-		StorageSlot:      srcStorageSlot,
+		ChainID:          p.srcChainID,
+		ContractAddr:     params.Address,
+		StorageSlot:      params.StorageSlot,
 		StorageValue:     storageValue,
 		L2WorldStateRoot: l2Header.Root,
 	}
@@ -298,7 +275,7 @@ func (p *Prover) GenerateConfigureAndProveCalldata(
 	}
 
 	calldata, err := p.nativeProver.EncodeConfigureAndProveCalldata(
-		*updateConfig,
+		*p.configProof,
 		proveArgs,
 		rlpEncodedL1Header,
 		rlpEncodedL2Header,

--- a/prover.go
+++ b/prover.go
@@ -1,14 +1,16 @@
 package fallback_prover
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/big"
-
-	"github.com/ethereum/go-ethereum/rlp"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	types2 "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/polymerdao/fallback_prover/provers"
 	"github.com/polymerdao/fallback_prover/types"
@@ -100,7 +102,7 @@ func (p *Prover) GenerateProveCalldata(
 	ctx context.Context,
 	params *ProveParams,
 ) (string, error) {
-	rlpEncodedL1Header, l1Header, err := p.l1OriginProver.ProveL1Origin(ctx, p.l1BlockHashOracle)
+	rlpEncodedL1Header, l1Header, err := p.GetL1Origin(ctx, params)
 	if err != nil {
 		return "", fmt.Errorf("failed to get L1 origin: %w", err)
 	}
@@ -165,7 +167,7 @@ func (p *Prover) GenerateUpdateAndProveCalldata(
 	ctx context.Context,
 	params *ProveParams,
 ) (string, error) {
-	rlpEncodedL1Header, l1Header, err := p.l1OriginProver.ProveL1Origin(ctx, p.l1BlockHashOracle)
+	rlpEncodedL1Header, l1Header, err := p.GetL1Origin(ctx, params)
 	if err != nil {
 		return "", fmt.Errorf("failed to get L1 origin: %w", err)
 	}
@@ -231,7 +233,7 @@ func (p *Prover) GenerateConfigureAndProveCalldata(
 	ctx context.Context,
 	params *ProveParams,
 ) (string, error) {
-	rlpEncodedL1Header, l1Header, err := p.l1OriginProver.ProveL1Origin(ctx, p.l1BlockHashOracle)
+	rlpEncodedL1Header, l1Header, err := p.GetL1Origin(ctx, params)
 	if err != nil {
 		return "", fmt.Errorf("failed to get L1 origin: %w", err)
 	}
@@ -290,4 +292,40 @@ func (p *Prover) GenerateConfigureAndProveCalldata(
 
 	// Return the calldata as a hex string
 	return "0x" + common.Bytes2Hex(calldata), nil
+}
+
+func (p *Prover) GetL1Origin(ctx context.Context, params *ProveParams) ([]byte, *types2.Header, error) {
+	if params.WaitForNewEpoch {
+		// Block until we see the L1 origin change
+		l1OriginHash, err := p.l1OriginProver.GetL1OriginHash(ctx, p.l1BlockHashOracle)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get initial L1 origin hash: %w", err)
+		}
+		i := uint(0)
+
+		t := time.NewTicker(time.Duration(params.EpochPollingFreq) * time.Second)
+		for {
+			select {
+			case <-ctx.Done():
+				return nil, nil, fmt.Errorf("context cancelled: %w", ctx.Err())
+			case <-t.C:
+				i++
+				newL1OriginHash, err := p.l1OriginProver.GetL1OriginHash(ctx, p.l1BlockHashOracle)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to get L1 origin: %w", err)
+				}
+				if !bytes.Equal(l1OriginHash.Bytes(), newL1OriginHash.Bytes()) {
+					return p.l1OriginProver.GetL1Origin(ctx, newL1OriginHash)
+				}
+				if i > params.EpochPollingTries {
+					return nil, nil, fmt.Errorf("timed out waiting for new epoch")
+				}
+			}
+		}
+	}
+	l1OriginHash, err := p.l1OriginProver.GetL1OriginHash(ctx, p.l1BlockHashOracle)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get L1 origin hash: %w", err)
+	}
+	return p.l1OriginProver.GetL1Origin(ctx, l1OriginHash)
 }

--- a/prover_test.go
+++ b/prover_test.go
@@ -48,7 +48,10 @@ func TestProver_GenerateProveCalldata(t *testing.T) {
 
 	// Create mock provers
 	mockL1OriginProver := &testutil.MockL1OriginProver{
-		ProveL1OriginFunc: func(ctx context.Context, l1OracleAddress common.Address) ([]byte, *types.Header, error) {
+		GetL1OriginHashFunc: func(ctx context.Context, l1OracleAddress common.Address) (common.Hash, error) {
+			return l1Block.Hash(), nil
+		},
+		GetL1OriginFunc: func(ctx context.Context, l1OriginHash common.Hash) ([]byte, *types.Header, error) {
 			return rlpEncodedL1Header, l1Block.Header(), nil
 		},
 	}
@@ -201,7 +204,10 @@ func TestProver_GenerateUpdateAndProveCalldata(t *testing.T) {
 
 	// Create mock provers
 	mockL1OriginProver := &testutil.MockL1OriginProver{
-		ProveL1OriginFunc: func(ctx context.Context, l1OracleAddress common.Address) ([]byte, *types.Header, error) {
+		GetL1OriginHashFunc: func(ctx context.Context, l1OracleAddress common.Address) (common.Hash, error) {
+			return l1Block.Hash(), nil
+		},
+		GetL1OriginFunc: func(ctx context.Context, l1OriginHash common.Hash) ([]byte, *types.Header, error) {
 			return rlpEncodedL1Header, l1Block.Header(), nil
 		},
 	}
@@ -391,7 +397,10 @@ func TestProver_GenerateConfigureAndProveCalldata(t *testing.T) {
 
 	// Create mock provers
 	mockL1OriginProver := &testutil.MockL1OriginProver{
-		ProveL1OriginFunc: func(ctx context.Context, l1OracleAddress common.Address) ([]byte, *types.Header, error) {
+		GetL1OriginHashFunc: func(ctx context.Context, l1OracleAddress common.Address) (common.Hash, error) {
+			return l1Block.Hash(), nil
+		},
+		GetL1OriginFunc: func(ctx context.Context, l1OriginHash common.Hash) ([]byte, *types.Header, error) {
 			return rlpEncodedL1Header, l1Block.Header(), nil
 		},
 	}

--- a/provers/interfaces.go
+++ b/provers/interfaces.go
@@ -23,7 +23,8 @@ type IRPCClient interface {
 }
 
 type IL1OriginProver interface {
-	ProveL1Origin(ctx context.Context, l1OracleAddress common.Address) ([]byte, *types.Header, error)
+	GetL1OriginHash(ctx context.Context, l1OracleAddress common.Address) (common.Hash, error)
+	GetL1Origin(ctx context.Context, l1OriginHash common.Hash) ([]byte, *types.Header, error)
 }
 
 type IStorageProver interface {

--- a/provers/op-stack-cannon.go
+++ b/provers/op-stack-cannon.go
@@ -273,7 +273,7 @@ func (p *OPStackCannonProver) GenerateSettledStateProof(
 	faultDisputeGameRootClaimSlot := common.BigToHash(big.NewInt(int64(config.StorageSlots[1])))
 	faultDisputeGameStatusSlot := common.BigToHash(big.NewInt(int64(config.StorageSlots[2])))
 
-	// Step 4: Interact with the DisputeGameFactory to get information about dispute games
+	// Interact with the DisputeGameFactory to get information about dispute games
 	disputeGameFactoryABI, err := getDisputeGameFactoryABI()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse DisputeGameFactory ABI: %w", err)

--- a/testutil/mock_interfaces.go
+++ b/testutil/mock_interfaces.go
@@ -56,12 +56,20 @@ func (m *MockRegistryProver) GenerateUpdateL2ConfigArgs(ctx context.Context, cha
 
 // MockL1OriginProver is a mock implementation of the provers.IL1OriginProver interface
 type MockL1OriginProver struct {
-	ProveL1OriginFunc func(ctx context.Context, l1OracleAddress common.Address) ([]byte, *types.Header, error)
+	GetL1OriginHashFunc func(ctx context.Context, l1OracleAddress common.Address) (common.Hash, error)
+	GetL1OriginFunc     func(ctx context.Context, l1OriginHash common.Hash) ([]byte, *types.Header, error)
 }
 
-func (m *MockL1OriginProver) ProveL1Origin(ctx context.Context, l1OracleAddress common.Address) ([]byte, *types.Header, error) {
-	if m.ProveL1OriginFunc != nil {
-		return m.ProveL1OriginFunc(ctx, l1OracleAddress)
+func (m *MockL1OriginProver) GetL1OriginHash(ctx context.Context, l1OracleAddress common.Address) (common.Hash, error) {
+	if m.GetL1OriginHashFunc != nil {
+		return m.GetL1OriginHashFunc(ctx, l1OracleAddress)
+	}
+	return common.Hash{}, nil
+}
+
+func (m *MockL1OriginProver) GetL1Origin(ctx context.Context, l1Hash common.Hash) ([]byte, *types.Header, error) {
+	if m.GetL1OriginFunc != nil {
+		return m.GetL1OriginFunc(ctx, l1Hash)
 	}
 	return nil, nil, nil
 }


### PR DESCRIPTION
One of the problems with combining all three proof steps into a single call (l1 view, settled l2, l2 storage proof) is that the L1 view supported by the l1 block hash oracle will change every epoch. This presents a race condition where we need to generate and submit our proof before the l1 view changes, because of the number of RPC calls involved this would be problematic if we begin our generation in one of the last blocks of an epoch. This functionality is a hacky solution to help prevent this by waiting until a new epoch is detected before beginning the proof generation process. Under good conditions this will give us 12 to generate and submit the proof, although its possible that during a catch up period that an epoch is less than 12 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added options to wait for a new L1 epoch before generating proofs, with configurable polling frequency and retry limits.

- **Refactor**
  - Streamlined CLI commands and configuration handling for L1 and L2 proving, improving clarity and separation of concerns.
  - Unified parameter passing into dedicated structs for easier and more consistent usage across commands.
  - Simplified and clarified the process for retrieving L1 origin information by splitting it into separate hash retrieval and origin fetching steps.
  - Updated prover initialization to precompute configuration proofs and cache oracle addresses for efficiency.

- **Bug Fixes**
  - Improved validation of required command-line flags for L1 and L2 operations.

- **Tests**
  - Updated and simplified test setups to match the new configuration and parameter structures.
  - Refactored mocks and method calls to align with the revised L1 origin proving interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->