### PR TITLE
Race condition fixes

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -65,7 +65,7 @@ var (
 		Usage: "Wait for a new L2 epoch before constructing proof if true." +
 			"Useful to avoid race condition with L1 blockhash oracle changing",
 		EnvVars: prefixEnvVars("WAIT_FOR_NEW_EPOCH"),
-		Value:   true,
+		Value:   false,
 	}
 	EpochPollingFreq = &cli.UintFlag{
 		Name:    "epoch-polling-freq",

--- a/prover.go
+++ b/prover.go
@@ -44,7 +44,6 @@ func NewProver(ctx context.Context, conf *ProveConfig) (*Prover, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to source L2 RPC: %w", err)
 	}
-	srcL2Client := ethclient.NewClient(srcL2RPC)
 
 	// Set up destination L2 clients
 	dstL2RPC, err := rpc.Dial(conf.DstL2RPC)
@@ -75,12 +74,12 @@ func NewProver(ctx context.Context, conf *ProveConfig) (*Prover, error) {
 
 	var settledStateProver provers.ISettledStateProver
 	if l2Config.ConfigType == "OPStackBedrock" {
-		settledStateProver, err = provers.NewOPStackBedrockProver(l1Client, l1RPC, srcL2Client, srcL2RPC)
+		settledStateProver, err = provers.NewOPStackBedrockProver(l1Client, l1RPC, srcL2RPC)
 		if err != nil {
 			return nil, err
 		}
 	} else if l2Config.ConfigType == "OPStackCannon" {
-		settledStateProver, err = provers.NewOPStackCannonProver(l1Client, l1RPC, srcL2Client, srcL2RPC)
+		settledStateProver, err = provers.NewOPStackCannonProver(l1Client, l1RPC, srcL2RPC)
 		if err != nil {
 			return nil, err
 		}
@@ -95,7 +94,7 @@ func NewProver(ctx context.Context, conf *ProveConfig) (*Prover, error) {
 
 	return &Prover{
 		l1OriginProver:     provers.NewL1OriginProver(l1Client, dstL2Client),
-		l2StorageProver:    provers.NewStorageProver(srcL2Client, srcL2RPC),
+		l2StorageProver:    provers.NewStorageProver(ethclient.NewClient(srcL2RPC), srcL2RPC),
 		nativeProver:       nativeProver,
 		settledStateProver: settledStateProver,
 		l2Config:           l2Config,

--- a/prover_test.go
+++ b/prover_test.go
@@ -66,8 +66,11 @@ func TestProver_GenerateProveCalldata(t *testing.T) {
 	}
 
 	mockBedrockProver := &testutil.MockOPStackBedrockProver{
-		GenerateSettledStateProofFunc: func(ctx context.Context, l1BlockNumber *big.Int, config *types2.L2ConfigInfo) ([]byte, *types.Header, error) {
+		GenerateSettledStateProofFunc: func(ctx context.Context, l1BlockNumber, outputIndex *big.Int, rootAddress common.Address, config *types2.L2ConfigInfo) ([]byte, *types.Header, error) {
 			return mockSettledStateProof, l2Header, nil
+		},
+		FindLatestResolvedFunc: func(ctx context.Context, config *types2.L2ConfigInfo) (*big.Int, common.Address, error) {
+			return big.NewInt(0), common.HexToAddress("0x1234"), nil
 		},
 	}
 
@@ -89,8 +92,11 @@ func TestProver_GenerateProveCalldata(t *testing.T) {
 	calldata, err := prover.GenerateProveCalldata(
 		context.Background(),
 		&ProveParams{
-			Address:     srcAddress,
-			StorageSlot: srcStorageSlot,
+			Address:           srcAddress,
+			StorageSlot:       srcStorageSlot,
+			WaitForNewEpoch:   false,
+			EpochPollingFreq:  5,
+			EpochPollingTries: 12,
 		},
 	)
 	require.NoError(t, err)
@@ -222,8 +228,11 @@ func TestProver_GenerateUpdateAndProveCalldata(t *testing.T) {
 	}
 
 	mockBedrockProver := &testutil.MockOPStackBedrockProver{
-		GenerateSettledStateProofFunc: func(ctx context.Context, l1BlockNumber *big.Int, config *types2.L2ConfigInfo) ([]byte, *types.Header, error) {
+		GenerateSettledStateProofFunc: func(ctx context.Context, l1BlockNumber, outputIndex *big.Int, rootAddress common.Address, config *types2.L2ConfigInfo) ([]byte, *types.Header, error) {
 			return mockSettledStateProof, l2Header, nil
+		},
+		FindLatestResolvedFunc: func(ctx context.Context, config *types2.L2ConfigInfo) (*big.Int, common.Address, error) {
+			return big.NewInt(0), common.HexToAddress("0x1234"), nil
 		},
 	}
 
@@ -251,8 +260,11 @@ func TestProver_GenerateUpdateAndProveCalldata(t *testing.T) {
 	calldata, err := prover.GenerateUpdateAndProveCalldata(
 		context.Background(),
 		&ProveParams{
-			Address:     srcAddress,
-			StorageSlot: srcStorageSlot,
+			Address:           srcAddress,
+			StorageSlot:       srcStorageSlot,
+			WaitForNewEpoch:   false,
+			EpochPollingFreq:  5,
+			EpochPollingTries: 12,
 		},
 	)
 	require.NoError(t, err)
@@ -415,8 +427,11 @@ func TestProver_GenerateConfigureAndProveCalldata(t *testing.T) {
 	}
 
 	mockCannonProver := &testutil.MockOPStackCannonProver{
-		GenerateSettledStateProofFunc: func(ctx context.Context, l1BlockNumber *big.Int, config *types2.L2ConfigInfo) ([]byte, *types.Header, error) {
+		GenerateSettledStateProofFunc: func(ctx context.Context, l1BlockNumber, outputIndex *big.Int, rootAddress common.Address, config *types2.L2ConfigInfo) ([]byte, *types.Header, error) {
 			return mockSettledStateProof, l2Header, nil
+		},
+		FindLatestResolvedFunc: func(ctx context.Context, config *types2.L2ConfigInfo) (*big.Int, common.Address, error) {
+			return big.NewInt(0), common.HexToAddress("0x1234"), nil
 		},
 	}
 
@@ -444,8 +459,11 @@ func TestProver_GenerateConfigureAndProveCalldata(t *testing.T) {
 	calldata, err := prover.GenerateConfigureAndProveCalldata(
 		context.Background(),
 		&ProveParams{
-			Address:     srcAddress,
-			StorageSlot: srcStorageSlot,
+			Address:           srcAddress,
+			StorageSlot:       srcStorageSlot,
+			WaitForNewEpoch:   false,
+			EpochPollingFreq:  5,
+			EpochPollingTries: 12,
 		},
 	)
 	require.NoError(t, err)

--- a/provers/interfaces.go
+++ b/provers/interfaces.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -20,6 +22,7 @@ type IEthClient interface {
 
 type IRPCClient interface {
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+	BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 }
 
 type IL1OriginProver interface {

--- a/provers/interfaces.go
+++ b/provers/interfaces.go
@@ -85,9 +85,13 @@ type INativeProver interface {
 }
 
 type ISettledStateProver interface {
+	FindLatestResolved(
+		ctx context.Context,
+		config *t.L2ConfigInfo) (*big.Int, common.Address, error)
 	GenerateSettledStateProof(
 		ctx context.Context,
-		l1BlockNumber *big.Int,
+		l1BlockNumber, outputIndex *big.Int,
+		rootAddress common.Address,
 		config *t.L2ConfigInfo) ([]byte, *types.Header, error)
 }
 

--- a/provers/op-stack-bedrock.go
+++ b/provers/op-stack-bedrock.go
@@ -21,13 +21,16 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+var _ ISettledStateProver = &OPStackBedrockProver{}
+
 // OPStackBedrockProver handles proof generation for OP Stack Bedrock chains
 type OPStackBedrockProver struct {
-	l1Client IEthClient
-	l1RPC    IRPCClient
-	l2Client IEthClient
-	l2RPC    IRPCClient
-	abi      abi.ABI
+	l1Client          IEthClient
+	l1RPC             IRPCClient
+	l2Client          IEthClient
+	l2RPC             IRPCClient
+	abi               abi.ABI
+	l2OutputOracleABI abi.ABI
 }
 
 // NewOPStackBedrockProver creates a new prover instance for OP Stack Bedrock
@@ -37,12 +40,18 @@ func NewOPStackBedrockProver(l1Client IEthClient, l1RPC IRPCClient, l2Client IEt
 		return nil, err
 	}
 
+	l2OutputAbiObj, err := getL2OutputOracleABI()
+	if err != nil {
+		return nil, err
+	}
+
 	return &OPStackBedrockProver{
-		l1Client: l1Client,
-		l1RPC:    l1RPC,
-		l2Client: l2Client,
-		l2RPC:    l2RPC,
-		abi:      abiObj,
+		l1Client:          l1Client,
+		l1RPC:             l1RPC,
+		l2Client:          l2Client,
+		l2RPC:             l2RPC,
+		abi:               abiObj,
+		l2OutputOracleABI: l2OutputAbiObj,
 	}, nil
 }
 
@@ -135,89 +144,56 @@ func getL2OutputOracleABI() (abi.ABI, error) {
 	]`))
 }
 
-// Constants for L2ToL1MessagePasser contract in OP Stack
-const (
-	L2MessagePasserAddress = "0x4200000000000000000000000000000000000016" // Standard address on OP Stack
+var (
+	L2MessagePasserAddress = common.HexToAddress("0x4200000000000000000000000000000000000016") // Standard address on OP Stack
 )
+
+func (p *OPStackBedrockProver) FindLatestResolved(ctx context.Context, config *types.L2ConfigInfo) (*big.Int, common.Address, error) {
+	if len(config.Addresses) == 0 || len(config.StorageSlots) == 0 {
+		return nil, common.Address{}, fmt.Errorf("invalid config: addresses or slots are empty")
+	}
+
+	latestOutputIndexData, err := p.l2OutputOracleABI.Pack("latestOutputIndex")
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("failed to pack getL2OutputIndexAfter: %w", err)
+	}
+
+	l2OutputOracleAddr := config.Addresses[0]
+
+	latestOutputIndexResult, err := p.l1Client.CallContract(ctx, ethereum.CallMsg{
+		To:   &l2OutputOracleAddr,
+		Data: latestOutputIndexData,
+	}, nil)
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("failed to call getL2OutputIndexAfter: %w", err)
+	}
+
+	latestOutputIndex := new(big.Int).SetBytes(latestOutputIndexResult)
+	if latestOutputIndex.Cmp(big.NewInt(0)) < 0 {
+		return nil, common.Address{}, fmt.Errorf("invalid latestOutputIndex: %s", latestOutputIndex.String())
+	}
+
+	return latestOutputIndex, l2OutputOracleAddr, nil
+}
 
 // GenerateSettledStateProof creates a proof for an OPStack Bedrock L2 against L1
 func (p *OPStackBedrockProver) GenerateSettledStateProof(
 	ctx context.Context,
-	l1BlockNumber *big.Int,
+	l1BlockNumber *big.Int, outputIndex *big.Int,
+	l2OutputOracleAddr common.Address,
 	config *types.L2ConfigInfo) ([]byte, *types2.Header, error) {
 	if len(config.Addresses) == 0 || len(config.StorageSlots) == 0 {
 		return nil, nil, fmt.Errorf("invalid config: addresses or slots are empty")
 	}
 
-	// Get the L2OutputOracle address from the config
-	l2OutputOracleAddr := config.Addresses[0]
-
-	// Step 1: Get the latest L2 block
-	l2Block, err := p.l2Client.BlockByNumber(ctx, nil) // nil means latest block
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get latest L2 block: %w", err)
-	}
-
-	l2BlockNumber := l2Block.Number()
-	l2Header := l2Block.Header()
-
-	// Step 2: Get the L2 message passer root using eth_getProof
-	// Get the storage root (storageHash) of the L2ToL1MessagePasser contract
-	messagePasserAddr := common.HexToAddress(L2MessagePasserAddress)
-
-	// Use eth_getProof to get the account state proof including the storage root
-	var messagePasserProof types.StorageProofResult
-	// Empty array for storage keys - we only need the account proof with storageHash
-	err = p.l2RPC.CallContext(
-		ctx,
-		&messagePasserProof,
-		"eth_getProof",
-		messagePasserAddr.Hex(),
-		[]string{}, // No specific storage keys needed, we just want the storageHash
-		toBlockNumArg(l2BlockNumber),
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get message passer proof: %w", err)
-	}
-
-	// The storageHash from the proof is the L2ToL1MessagePasser root we need
-	messagePasserRoot := messagePasserProof.StorageHash
-
-	// Step 3: Get the L2 output index for the L2 block using L2OutputOracle on L1
-	outputOracleABI, err := getL2OutputOracleABI()
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse L2OutputOracle ABI: %w", err)
-	}
-
-	outputIndexData, err := outputOracleABI.Pack("getL2OutputIndexAfter", l2BlockNumber)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to pack getL2OutputIndexAfter: %w", err)
-	}
-
-	outputIndexResult, err := p.l1Client.CallContract(ctx, ethereum.CallMsg{
-		To:   &l2OutputOracleAddr,
-		Data: outputIndexData,
-	}, l1BlockNumber)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to call getL2OutputIndexAfter: %w", err)
-	}
-
-	// Properly handle the unpacking - the value is a uint256 directly in the result bytes
-	outputIndex := new(big.Int).SetBytes(outputIndexResult)
-	// Check for errors or zero index
-	if outputIndex.Cmp(big.NewInt(0)) < 0 {
-		return nil, nil, fmt.Errorf("invalid output index: %s", outputIndex.String())
-	}
-
-	// Step 4: Get the output proposal for the L2 output index
-	outputData, err := outputOracleABI.Pack("getL2Output", outputIndex)
+	l2OutputData, err := p.l2OutputOracleABI.Pack("getL2Output", outputIndex)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to pack getL2Output: %w", err)
 	}
 
-	outputResult, err := p.l1Client.CallContract(ctx, ethereum.CallMsg{
+	l2OutputResult, err := p.l1Client.CallContract(ctx, ethereum.CallMsg{
 		To:   &l2OutputOracleAddr,
-		Data: outputData,
+		Data: l2OutputData,
 	}, l1BlockNumber)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to call getL2Output: %w", err)
@@ -233,18 +209,41 @@ func (p *OPStackBedrockProver) GenerateSettledStateProof(
 	var outputProposal OutputProposal
 
 	// If the direct unpack fails, try the byte-by-byte approach
-	if len(outputResult) >= 96 { // 32 bytes for outputRoot, 32 bytes for timestamp, 32 bytes for l2BlockNumber
-		copy(outputProposal.OutputRoot[:], outputResult[:32])
-		outputProposal.Timestamp = new(big.Int).SetBytes(outputResult[32:64])
-		outputProposal.L2BlockNumber = new(big.Int).SetBytes(outputResult[64:96])
+	if len(l2OutputResult) >= 96 { // 32 bytes for outputRoot, 32 bytes for timestamp, 32 bytes for l2BlockNumber
+		copy(outputProposal.OutputRoot[:], l2OutputResult[:32])
+		outputProposal.Timestamp = new(big.Int).SetBytes(l2OutputResult[32:64])
+		outputProposal.L2BlockNumber = new(big.Int).SetBytes(l2OutputResult[64:96])
 	} else {
 		// Only try the ABI unpacking as a fallback
-		if err := outputOracleABI.UnpackIntoInterface(&outputProposal, "getL2Output", outputResult); err != nil {
+		if err := p.l2OutputOracleABI.UnpackIntoInterface(&outputProposal, "getL2Output", l2OutputResult); err != nil {
 			return nil, nil, fmt.Errorf("failed to unpack output proposal: %w", err)
 		}
 	}
 
-	// Step 5: Get the storage proof for the output proposal
+	l2Block, err := p.l2Client.BlockByNumber(ctx, outputProposal.L2BlockNumber) // nil means latest block
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get latest L2 block: %w", err)
+	}
+
+	// Use eth_getProof to get L2toL1MessagePasser info at the L2 output height
+	var messagePasserProof types.StorageProofResult
+	// Empty array for storage keys - we only need the account proof with storageHash
+	err = p.l2RPC.CallContext(
+		ctx,
+		&messagePasserProof,
+		"eth_getProof",
+		L2MessagePasserAddress.Hex(),
+		[]string{}, // No specific storage keys needed, we just want the storageHash
+		toBlockNumArg(outputProposal.L2BlockNumber),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get message passer proof: %w", err)
+	}
+
+	// The storageHash from the proof is the L2ToL1MessagePasser root we need
+	messagePasserRoot := messagePasserProof.StorageHash
+
+	// Get the storage proof for the output proposal
 	// Calculate the storage slot for the output index
 	var storageSlot common.Hash
 	if len(config.StorageSlots) > 0 {
@@ -271,13 +270,11 @@ func (p *OPStackBedrockProver) GenerateSettledStateProof(
 		return nil, nil, fmt.Errorf("failed to get output oracle proof: %w", err)
 	}
 
-	// Convert storage proof to bytes
 	l1StorageProof := make([][]byte, len(proof.StorageProof[0].Proof))
 	for i, p := range proof.StorageProof[0].Proof {
 		l1StorageProof[i] = common.FromHex(p)
 	}
 
-	// Create RLP encoded account data
 	account := Account{
 		Nonce:    uint64(*proof.Nonce),
 		Balance:  proof.Balance.ToInt(),
@@ -290,13 +287,11 @@ func (p *OPStackBedrockProver) GenerateSettledStateProof(
 		return nil, nil, fmt.Errorf("failed to RLP encode account: %w", err)
 	}
 
-	// Convert account proof to bytes
 	l1AccountProof := make([][]byte, len(proof.AccountProof))
 	for i, p := range proof.AccountProof {
 		l1AccountProof[i] = common.FromHex(p)
 	}
 
-	// Step 6: Package everything together in the format expected by the prover contract
 	outputIndexBytes := make([]byte, 32)
 	binary.BigEndian.PutUint64(outputIndexBytes[24:32], outputIndex.Uint64())
 
@@ -315,5 +310,5 @@ func (p *OPStackBedrockProver) GenerateSettledStateProof(
 		return nil, nil, fmt.Errorf("failed to RLP encode settled state proof: %w", err)
 	}
 
-	return settledStateProof, l2Header, nil
+	return settledStateProof, l2Block.Header(), nil
 }

--- a/provers/op-stack-bedrock_test.go
+++ b/provers/op-stack-bedrock_test.go
@@ -6,15 +6,57 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/polymerdao/fallback_prover/testutil"
 	types2 "github.com/polymerdao/fallback_prover/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestOPStackBedrockProver_FindLatestResolved(t *testing.T) {
+
+	// Create test data
+	l2OutputOracleAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+	latestOutputIndex := big.NewInt(123)
+
+	// Create L2 config
+	config := &types2.L2ConfigInfo{
+		ConfigType: "OPStackBedrock",
+		Addresses: []common.Address{
+			l2OutputOracleAddr,
+		},
+		StorageSlots: []uint64{
+			0x123, // Some storage slot value
+		},
+	}
+
+	// Create mock L1 client
+	mockL1Client := &testutil.MockEthClient{
+		CallContractFunc: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			// Check that we're calling the right contract
+			require.Equal(t, l2OutputOracleAddr.Hex(), msg.To.Hex())
+
+			// Return the latestOutputIndex
+			return common.LeftPadBytes(latestOutputIndex.Bytes(), 32), nil
+		},
+	}
+
+	// Create the OPStackBedrockProver
+	prover, err := NewOPStackBedrockProver(mockL1Client, nil, nil)
+	require.NoError(t, err)
+
+	// Call the method being tested
+	outputIndex, addr, err := prover.FindLatestResolved(context.Background(), config)
+	require.NoError(t, err)
+
+	// Verify the results
+	assert.Equal(t, latestOutputIndex.String(), outputIndex.String())
+	assert.Equal(t, l2OutputOracleAddr.Hex(), addr.Hex())
+}
 
 func TestOPStackBedrockProver_GenerateSettledStateProof(t *testing.T) {
 	// Parse the L2OutputOracle ABI
@@ -28,7 +70,6 @@ func TestOPStackBedrockProver_GenerateSettledStateProof(t *testing.T) {
 
 	// Create a test header and block
 	l2Header := testutil.CreateTestHeader(t)
-	l2Block := testutil.CreateTestBlock(t, l2Header)
 
 	// Create L2 config
 	config := &types2.L2ConfigInfo{
@@ -38,13 +79,6 @@ func TestOPStackBedrockProver_GenerateSettledStateProof(t *testing.T) {
 		},
 		StorageSlots: []uint64{
 			0x123, // Some storage slot value
-		},
-	}
-
-	// Create mock L2 client
-	mockL2Client := &testutil.MockEthClient{
-		BlockByNumberFunc: func(ctx context.Context, number *big.Int) (*types.Block, error) {
-			return l2Block, nil
 		},
 	}
 
@@ -65,15 +99,7 @@ func TestOPStackBedrockProver_GenerateSettledStateProof(t *testing.T) {
 			methodSigHex := hexutil.Encode(methodSig)
 
 			// Get method IDs from the L2OutputOracle ABI
-			getL2OutputIndexAfterMethodID := l2OutputOracleABI.Methods["getL2OutputIndexAfter"].ID
 			getL2OutputMethodID := l2OutputOracleABI.Methods["getL2Output"].ID
-
-			// getL2OutputIndexAfter method
-			if methodSigHex == hexutil.Encode(getL2OutputIndexAfterMethodID) {
-				packedData, err := l2OutputOracleABI.Pack("getL2OutputIndexAfter", outputIndex)
-				require.NoError(t, err)
-				return packedData, nil
-			}
 
 			// getL2Output method
 			if methodSigHex == hexutil.Encode(getL2OutputMethodID) {
@@ -114,6 +140,51 @@ func TestOPStackBedrockProver_GenerateSettledStateProof(t *testing.T) {
 			}
 			return nil
 		},
+		BatchCallContextFunc: func(ctx context.Context, b []rpc.BatchElem) error {
+			// Process each element in the batch
+			for i := range b {
+				elem := &b[i]
+				if elem.Method == "eth_getProof" {
+					// Mock a storage proof result
+					mockProof := testutil.MockStorageProofResult(
+						t,
+						l2OutputOracleAddr,
+						common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000123"),
+						big.NewInt(456),
+					)
+
+					// Marshal to JSON and unmarshal into the result
+					mockProofJSON, err := json.Marshal(mockProof)
+					require.NoError(t, err)
+					err = json.Unmarshal(mockProofJSON, elem.Result)
+					if err != nil {
+						return err
+					}
+				} else if elem.Method == "eth_call" {
+					// Mock call result for getL2Output
+					outputRoot := common.HexToHash("0x9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba")
+					timestamp := big.NewInt(1000000000)
+					l2BlockNumber := big.NewInt(12345)
+
+					// Manually create the response - 32 bytes for each field
+					responseData := make([]byte, 96)
+					copy(responseData[0:32], outputRoot.Bytes())
+					copy(responseData[32:64], common.LeftPadBytes(timestamp.Bytes(), 32))
+					copy(responseData[64:96], common.LeftPadBytes(l2BlockNumber.Bytes(), 32))
+
+					// Convert to hex string for RPC response
+					hexData := "0x" + common.Bytes2Hex(responseData)
+
+					// Type assert to get the right result pointer
+					if resultPtr, ok := elem.Result.(*[]byte); ok {
+						*resultPtr = responseData
+					} else if resultPtr, ok := elem.Result.(*string); ok {
+						*resultPtr = hexData
+					}
+				}
+			}
+			return nil
+		},
 	}
 
 	mockL2RPC := &testutil.MockRPCClient{
@@ -137,16 +208,53 @@ func TestOPStackBedrockProver_GenerateSettledStateProof(t *testing.T) {
 			}
 			return nil
 		},
+		BatchCallContextFunc: func(ctx context.Context, b []rpc.BatchElem) error {
+			// Process each element in the batch
+			for i := range b {
+				elem := &b[i]
+				if elem.Method == "eth_getProof" {
+					// Mock a message passer proof result with the specific storage hash we want
+					mockProof := map[string]interface{}{
+						"address":      "0x4200000000000000000000000000000000000016",
+						"accountProof": []string{"0xproof1", "0xproof2"},
+						"balance":      "0x0",
+						"codeHash":     "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+						"nonce":        "0x0",
+						"storageHash":  messagePasserRoot.Hex(),
+						"storageProof": []interface{}{},
+					}
+
+					// Marshal to JSON and unmarshal into the result
+					mockProofJSON, err := json.Marshal(mockProof)
+					require.NoError(t, err)
+					err = json.Unmarshal(mockProofJSON, elem.Result)
+					if err != nil {
+						return err
+					}
+				} else if elem.Method == "eth_getBlockByNumber" {
+					// Set the block data for json.RawMessage
+					if rawMsg, ok := elem.Result.(*json.RawMessage); ok {
+						// Marshal the block into JSON format for the proper RawMessage processing
+						blockJSON, err := json.Marshal(l2Header)
+						require.NoError(t, err)
+						*rawMsg = blockJSON
+					}
+				}
+			}
+			return nil
+		},
 	}
 
 	// Create the OPStackBedrockProver
-	prover, err := NewOPStackBedrockProver(mockL1Client, mockL1RPC, mockL2Client, mockL2RPC)
+	prover, err := NewOPStackBedrockProver(mockL1Client, mockL1RPC, mockL2RPC)
 	require.NoError(t, err)
 
 	// Call the method being tested
 	settledStateProof, l2Header, err := prover.GenerateSettledStateProof(
 		context.Background(),
 		expectedL1BlockNumber,
+		outputIndex,
+		l2OutputOracleAddr,
 		config,
 	)
 	require.NoError(t, err)

--- a/provers/op-stack-cannon_test.go
+++ b/provers/op-stack-cannon_test.go
@@ -10,28 +10,21 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/polymerdao/fallback_prover/testutil"
 	types2 "github.com/polymerdao/fallback_prover/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestOPStackCannonProver_GenerateSettledStateProof(t *testing.T) {
+func TestOPStackCannonProver_FindLatestResolved(t *testing.T) {
 	// Create test data
 	disputeGameFactoryAddr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
 	disputeGameAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
 	gameCount := big.NewInt(1) // Only have one game in the factory
 	gameIndex := big.NewInt(0) // The first and only game
-	rootClaim := common.HexToHash("0x9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba")
-	gameStatus := uint8(2) // RESOLVED status value (important for this test)
-	messagePasserRoot := common.HexToHash("0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321")
-	faultDisputeGameStateRoot := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
-
-	// Create a test header and block
-	l2Header := testutil.CreateTestHeader(t)
-	l2Block := testutil.CreateTestBlock(t, l2Header)
+	gameStatus := uint8(2)     // RESOLVED status value (important for this test)
 
 	// Create L2 config
 	config := &types2.L2ConfigInfo{
@@ -46,10 +39,106 @@ func TestOPStackCannonProver_GenerateSettledStateProof(t *testing.T) {
 		},
 	}
 
-	// Create mock L2 client
-	mockL2Client := &testutil.MockEthClient{
-		BlockByNumberFunc: func(ctx context.Context, number *big.Int) (*types.Block, error) {
-			return l2Block, nil
+	// Create mock L1 client
+	mockL1Client := &testutil.MockEthClient{
+		CallContractFunc: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			// Check that we're calling one of the expected contracts
+			if msg.To.Hex() == disputeGameFactoryAddr.Hex() {
+				// Debug log the incoming message data
+				t.Logf("Calling factory contract with data: %x", msg.Data)
+
+				// Determine which method is being called by looking at the method signature
+				methodSig := msg.Data[:4]
+				methodSigHex := hexutil.Encode(methodSig)
+
+				// Get method signatures from the same ABI used in the code being tested
+				disputeGameFactoryABI, _ := getDisputeGameFactoryABI()
+				gameCountMethodID := disputeGameFactoryABI.Methods["gameCount"].ID
+				gameAtIndexMethodID := disputeGameFactoryABI.Methods["gameAtIndex"].ID
+
+				// gameCount method
+				if methodSigHex == hexutil.Encode(gameCountMethodID) {
+					t.Logf("Handling gameCount call...")
+					// Ensure we're returning a non-empty response
+					response := common.LeftPadBytes(gameCount.Bytes(), 32)
+					t.Logf("Returning gameCount response: %x (len: %d)", response, len(response))
+					return response, nil
+				}
+
+				// gameAtIndex method
+				if methodSigHex == hexutil.Encode(gameAtIndexMethodID) {
+					t.Logf("Handling gameAtIndex call...")
+					// Return the address as a 32-byte value
+					return common.LeftPadBytes(disputeGameAddr.Bytes(), 32), nil
+				}
+
+				return nil, fmt.Errorf("Unknown method signature: %s for contract  %s", methodSigHex, msg.To.Hex())
+			} else if msg.To.Hex() == disputeGameAddr.Hex() {
+				// Debug log the incoming message data
+				t.Logf("Calling dispute game contract with data: %x", msg.Data)
+
+				// Determine which method is being called by looking at the method signature
+				methodSig := msg.Data[:4]
+				methodSigHex := hexutil.Encode(methodSig)
+
+				// Get method signatures from the same ABI used in the code being tested
+				faultDisputeGameABI, _ := getFaultDisputeGameABI()
+				statusMethodID := faultDisputeGameABI.Methods["status"].ID
+
+				// status method
+				if methodSigHex == hexutil.Encode(statusMethodID) {
+					t.Logf("Handling status call...")
+					// Return the status as a byte
+					statusBytes := []byte{gameStatus}
+					return common.LeftPadBytes(statusBytes, 32), nil
+				}
+
+				return nil, fmt.Errorf("Unknown method signature: %s for contract  %s", methodSigHex, msg.To.Hex())
+			}
+
+			t.Logf("CallContract called with unknown address: %s", msg.To.Hex())
+			return nil, nil
+		},
+	}
+
+	// Create the OPStackCannonProver
+	prover, err := NewOPStackCannonProver(mockL1Client, nil, nil)
+	require.NoError(t, err)
+
+	// Call the method being tested
+	outputIndex, addr, err := prover.FindLatestResolved(context.Background(), config)
+	require.NoError(t, err)
+
+	// Verify the results
+	assert.Equal(t, gameIndex.String(), outputIndex.String())
+	assert.Equal(t, disputeGameAddr.Hex(), addr.Hex())
+}
+
+func TestOPStackCannonProver_GenerateSettledStateProof(t *testing.T) {
+	// Create test data
+	disputeGameFactoryAddr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	disputeGameAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+	gameCount := big.NewInt(1) // Only have one game in the factory
+	gameIndex := big.NewInt(0) // The first and only game
+	rootClaim := common.HexToHash("0x9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba")
+	gameStatus := uint8(2) // RESOLVED status value (important for this test)
+	messagePasserRoot := common.HexToHash("0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321")
+	faultDisputeGameStateRoot := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+	disputeGameABI, err := getFaultDisputeGameABI()
+	require.NoError(t, err)
+	// Create a test header and block
+	l2Header := testutil.CreateTestHeader(t)
+
+	// Create L2 config
+	config := &types2.L2ConfigInfo{
+		ConfigType: "OPStackCannon",
+		Addresses: []common.Address{
+			disputeGameFactoryAddr,
+		},
+		StorageSlots: []uint64{
+			0x123, // DisputeGameFactory list slot
+			0x456, // FaultDisputeGame rootClaim slot
+			0x789, // FaultDisputeGame status slot
 		},
 	}
 
@@ -220,6 +309,119 @@ func TestOPStackCannonProver_GenerateSettledStateProof(t *testing.T) {
 			}
 			return nil
 		},
+		BatchCallContextFunc: func(ctx context.Context, b []rpc.BatchElem) error {
+			// Process each element in the batch
+			for i := range b {
+				elem := &b[i]
+				if elem.Method == "eth_getProof" {
+					// Get the address from the arguments
+					args := elem.Args
+					if len(args) < 1 {
+						continue
+					}
+					address, ok := args[0].(string)
+					if !ok {
+						continue
+					}
+
+					if address == disputeGameFactoryAddr.Hex() {
+						// Mock a dispute game factory proof
+						mockProof := testutil.MockStorageProofResult(
+							t,
+							disputeGameFactoryAddr,
+							common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000123"),
+							gameIndex,
+						)
+
+						// Marshal to JSON and unmarshal into the result
+						mockProofJSON, err := json.Marshal(mockProof)
+						require.NoError(t, err)
+						err = json.Unmarshal(mockProofJSON, elem.Result)
+						if err != nil {
+							return err
+						}
+					} else if address == disputeGameAddr.Hex() {
+						// Mock a fault dispute game proof
+						mockProof := map[string]interface{}{
+							"address":      disputeGameAddr.Hex(),
+							"accountProof": []string{"0xproof1", "0xproof2"},
+							"balance":      "0x0",
+							"codeHash":     "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+							"nonce":        "0x0",
+							"storageHash":  faultDisputeGameStateRoot.Hex(),
+							"storageProof": []map[string]interface{}{
+								{
+									"key":   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000456").Hex(),
+									"value": rootClaim.Hex(),
+									"proof": []string{"0xproof1", "0xproof2"},
+								},
+								{
+									"key":   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000789").Hex(),
+									"value": "0x2", // Game status
+									"proof": []string{"0xproof1", "0xproof2"},
+								},
+							},
+						}
+
+						// Marshal to JSON and unmarshal into the result
+						mockProofJSON, err := json.Marshal(mockProof)
+						require.NoError(t, err)
+						err = json.Unmarshal(mockProofJSON, elem.Result)
+						if err != nil {
+							return err
+						}
+					}
+				} else if elem.Method == "eth_call" {
+					// Get the first argument which should be the call message
+					if len(elem.Args) < 1 {
+						continue
+					}
+
+					var msgData []byte
+					if callMsg, ok := elem.Args[0].(ethereum.CallMsg); ok {
+						msgData = callMsg.Data
+					} else {
+						continue
+					}
+
+					if len(msgData) < 4 {
+						continue
+					}
+
+					methodID := msgData[:4]
+					methodIDHex := hexutil.Encode(methodID)
+					createdAtSig := hexutil.Encode(disputeGameABI.Methods["createdAt"].ID)
+					resolvedAtSig := hexutil.Encode(disputeGameABI.Methods["resolvedAt"].ID)
+					l2BlockNumberSig := hexutil.Encode(disputeGameABI.Methods["l2BlockNumber"].ID)
+
+					// Match different method IDs
+					switch methodIDHex {
+					case createdAtSig:
+						// Return timestamp (uint64) as example value: 1650000000
+						createdAt := uint64(1650000000)
+						responseData := common.LeftPadBytes(new(big.Int).SetUint64(createdAt).Bytes(), 32)
+						if resultPtr, ok := elem.Result.(*[]byte); ok {
+							*resultPtr = responseData
+						}
+					case resolvedAtSig:
+						// Return timestamp (uint64) as example value: 1650001000
+						resolvedAt := uint64(1650001000)
+						responseData := common.LeftPadBytes(new(big.Int).SetUint64(resolvedAt).Bytes(), 32)
+						if resultPtr, ok := elem.Result.(*[]byte); ok {
+							*resultPtr = responseData
+						}
+					case l2BlockNumberSig:
+						// Return a block number (uint64) - example value: 12345
+						blockNumber := uint64(12345)
+						responseData := common.LeftPadBytes(new(big.Int).SetUint64(blockNumber).Bytes(), 32)
+						if resultPtr, ok := elem.Result.(*[]byte); ok {
+							*resultPtr = responseData
+						}
+					}
+				}
+			}
+			return nil
+		},
 	}
 
 	mockL2RPC := &testutil.MockRPCClient{
@@ -243,6 +445,41 @@ func TestOPStackCannonProver_GenerateSettledStateProof(t *testing.T) {
 			}
 			return nil
 		},
+		BatchCallContextFunc: func(ctx context.Context, b []rpc.BatchElem) error {
+			// Process each element in the batch
+			for i := range b {
+				elem := &b[i]
+				if elem.Method == "eth_getProof" {
+					// Mock a message passer proof result with the specific storage hash we want
+					mockProof := map[string]interface{}{
+						"address":      "0x4200000000000000000000000000000000000016",
+						"accountProof": []string{"0xproof1", "0xproof2"},
+						"balance":      "0x0",
+						"codeHash":     "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+						"nonce":        "0x0",
+						"storageHash":  messagePasserRoot.Hex(),
+						"storageProof": []interface{}{},
+					}
+
+					// Marshal to JSON and unmarshal into the result
+					mockProofJSON, err := json.Marshal(mockProof)
+					require.NoError(t, err)
+					err = json.Unmarshal(mockProofJSON, elem.Result)
+					if err != nil {
+						return err
+					}
+				} else if elem.Method == "eth_getBlockByNumber" {
+					// Set the block data for json.RawMessage
+					if rawMsg, ok := elem.Result.(*json.RawMessage); ok {
+						// Marshal the block into JSON format for the proper RawMessage processing
+						blockJSON, err := json.Marshal(l2Header)
+						require.NoError(t, err)
+						*rawMsg = blockJSON
+					}
+				}
+			}
+			return nil
+		},
 	}
 
 	// Set up RLP encoded L2 header for test to check if it matches the result
@@ -250,13 +487,15 @@ func TestOPStackCannonProver_GenerateSettledStateProof(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the OPStackCannonProver
-	prover, err := NewOPStackCannonProver(mockL1Client, mockL1RPC, mockL2Client, mockL2RPC)
+	prover, err := NewOPStackCannonProver(mockL1Client, mockL1RPC, mockL2RPC)
 	require.NoError(t, err)
 
 	// Call the method being tested
 	settledStateProof, l2Header, err := prover.GenerateSettledStateProof(
 		context.Background(),
 		expectedL1BlockNumber,
+		gameIndex,
+		disputeGameAddr,
 		config,
 	)
 	require.NoError(t, err)

--- a/testutil/mock_interfaces.go
+++ b/testutil/mock_interfaces.go
@@ -104,24 +104,40 @@ func (m *MockStorageProver) GenerateStorageProof(ctx context.Context, contractAd
 
 // MockOPStackBedrockProver is a mock implementation of the provers.ISettledStateProver interface
 type MockOPStackBedrockProver struct {
-	GenerateSettledStateProofFunc func(ctx context.Context, l1BlockNumber *big.Int, config *t.L2ConfigInfo) ([]byte, *types.Header, error)
+	FindLatestResolvedFunc        func(ctx context.Context, config *t.L2ConfigInfo) (*big.Int, common.Address, error)
+	GenerateSettledStateProofFunc func(ctx context.Context, l1BlockNumber, outputIndex *big.Int, rootAddress common.Address, config *t.L2ConfigInfo) ([]byte, *types.Header, error)
 }
 
-func (m *MockOPStackBedrockProver) GenerateSettledStateProof(ctx context.Context, l1BlockNumber *big.Int, config *t.L2ConfigInfo) ([]byte, *types.Header, error) {
+func (m *MockOPStackBedrockProver) FindLatestResolved(ctx context.Context, config *t.L2ConfigInfo) (*big.Int, common.Address, error) {
+	if m.FindLatestResolvedFunc != nil {
+		return m.FindLatestResolvedFunc(ctx, config)
+	}
+	return big.NewInt(0), common.Address{}, nil
+}
+
+func (m *MockOPStackBedrockProver) GenerateSettledStateProof(ctx context.Context, l1BlockNumber, outputIndex *big.Int, rootAddress common.Address, config *t.L2ConfigInfo) ([]byte, *types.Header, error) {
 	if m.GenerateSettledStateProofFunc != nil {
-		return m.GenerateSettledStateProofFunc(ctx, l1BlockNumber, config)
+		return m.GenerateSettledStateProofFunc(ctx, l1BlockNumber, outputIndex, rootAddress, config)
 	}
 	return nil, nil, nil
 }
 
 // MockOPStackCannonProver is a mock implementation of the provers.ISettledStateProver interface
 type MockOPStackCannonProver struct {
-	GenerateSettledStateProofFunc func(ctx context.Context, l1BlockNumber *big.Int, config *t.L2ConfigInfo) ([]byte, *types.Header, error)
+	FindLatestResolvedFunc        func(ctx context.Context, config *t.L2ConfigInfo) (*big.Int, common.Address, error)
+	GenerateSettledStateProofFunc func(ctx context.Context, l1BlockNumber, outputIndex *big.Int, rootAddress common.Address, config *t.L2ConfigInfo) ([]byte, *types.Header, error)
 }
 
-func (m *MockOPStackCannonProver) GenerateSettledStateProof(ctx context.Context, l1BlockNumber *big.Int, config *t.L2ConfigInfo) ([]byte, *types.Header, error) {
+func (m *MockOPStackCannonProver) FindLatestResolved(ctx context.Context, config *t.L2ConfigInfo) (*big.Int, common.Address, error) {
+	if m.FindLatestResolvedFunc != nil {
+		return m.FindLatestResolvedFunc(ctx, config)
+	}
+	return big.NewInt(0), common.Address{}, nil
+}
+
+func (m *MockOPStackCannonProver) GenerateSettledStateProof(ctx context.Context, l1BlockNumber, outputIndex *big.Int, rootAddress common.Address, config *t.L2ConfigInfo) ([]byte, *types.Header, error) {
 	if m.GenerateSettledStateProofFunc != nil {
-		return m.GenerateSettledStateProofFunc(ctx, l1BlockNumber, config)
+		return m.GenerateSettledStateProofFunc(ctx, l1BlockNumber, outputIndex, rootAddress, config)
 	}
 	return nil, nil, nil
 }

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,12 +42,20 @@ func (m *MockEthClient) BlockByNumber(ctx context.Context, number *big.Int) (*ty
 
 // MockRPCClient is a mock implementation of the IRPCClient for testing
 type MockRPCClient struct {
-	CallContextFunc func(ctx context.Context, result interface{}, method string, args ...interface{}) error
+	CallContextFunc      func(ctx context.Context, result interface{}, method string, args ...interface{}) error
+	BatchCallContextFunc func(ctx context.Context, b []rpc.BatchElem) error
 }
 
 func (m *MockRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
 	if m.CallContextFunc != nil {
 		return m.CallContextFunc(ctx, result, method, args...)
+	}
+	return nil
+}
+
+func (m *MockRPCClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	if m.BatchCallContextFunc != nil {
+		return m.BatchCallContextFunc(ctx, b)
 	}
 	return nil
 }


### PR DESCRIPTION
1. Split GenerateSettledStateProof into two methdos: GenerateSettledStateProof and FindLatestResolved. FindLatestResolved obtains all the information that can be obtained before an L1 origin has been selected, to minimize the number of RPC calls that need to be made between origin selection and proof submission.
2. Batch RPC calls in GenerateSettledStateProof where possible. Note that you can't use rpc.BatchElems for eth_call, so there is still further optimization that could be done by multiplexing these calls on the client side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for resolving the latest settled state and dispute game information, improving proof generation for OP Stack Bedrock and Cannon chains.

- **Bug Fixes**
  - Enhanced robustness and accuracy of settled state proof generation by using explicit L1 and L2 contract queries and batch RPC calls.

- **Tests**
  - Introduced new tests for resolving the latest state and dispute games.
  - Updated existing tests to cover new proof generation logic and batch RPC handling.

- **Chores**
  - Changed the default value of the `wait-for-new-epoch` CLI flag from true to false.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->